### PR TITLE
fix: Set NODE_ENV=test in vitest config for API tests

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    env: {
+      NODE_ENV: 'test',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Fixes CI test failures on staging branch by ensuring NODE_ENV is properly set to 'test' in the vitest configuration. This allows the fileStorage service to properly seed sample data during tests, preventing empty prompt lists that caused test failures in CI environment.

The issue occurred because:
- API tests rely on seedSampleData() which only runs in 'test' or 'development' mode
- CI environment was not setting NODE_ENV correctly for vitest
- This caused tests expecting sample prompts to fail with empty data

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## 📝 Description

Brief description of changes made.

## 🔗 Related Issues

Fixes #(issue number)

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates

## ✅ Quality Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## 🔍 Testing

### Test Commands Run
- [ ] `pnpm typecheck` - No type errors
- [ ] `pnpm build` - Builds successfully  
- [ ] `pnpm lint` - No lint errors
- [ ] `pnpm test` - All tests pass

### Manual Testing
Describe the tests you ran to verify your changes:

1. Test A
2. Test B
3. Test C

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 📋 Additional Notes

Any additional information that reviewers should know.