### PR TITLE
fix: Correct DMG file path handling in hdiutil create command

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -224,11 +224,12 @@ jobs:
             
             # Create new DMG with the fixed app
             DMG_NAME=$(basename "$DMG_PATH")
+            TEMP_DMG_PATH="${DMG_PATH%.*}_temp"
             echo "📦 Creating new DMG with fixed app..."
-            hdiutil create -srcfolder "$TEMP_DIR/app.app" -volname "prompalette-staging" -ov -format UDZO "$DMG_PATH.tmp"
+            hdiutil create -srcfolder "$TEMP_DIR/app.app" -volname "prompalette-staging" -ov -format UDZO "$TEMP_DMG_PATH"
             
             # Replace the original DMG
-            mv "$DMG_PATH.tmp" "$DMG_PATH"
+            mv "$TEMP_DMG_PATH.dmg" "$DMG_PATH"
             
             # Clean up
             rm -rf "$TEMP_DIR"


### PR DESCRIPTION
- hdiutil create automatically adds .dmg extension to output filename
- Changed to use extension-less temporary path and account for auto-added .dmg
- This fixes the 'No such file or directory' error in CI/CD

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## 📝 Description

Brief description of changes made.

## 🔗 Related Issues

Fixes #(issue number)

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates

## ✅ Quality Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## 🔍 Testing

### Test Commands Run
- [ ] `pnpm typecheck` - No type errors
- [ ] `pnpm build` - Builds successfully  
- [ ] `pnpm lint` - No lint errors
- [ ] `pnpm test` - All tests pass

### Manual Testing
Describe the tests you ran to verify your changes:

1. Test A
2. Test B
3. Test C

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 📋 Additional Notes

Any additional information that reviewers should know.