### PR TITLE
fix: Preserve DMG structure and app name in code signing fix

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -209,24 +209,33 @@ jobs:
             # Mount the DMG
             hdiutil attach "$DMG_PATH" -mountpoint "$TEMP_DIR/mount" -readonly -noautoopen
             
-            # Copy the app to a writable location
-            cp -r "$TEMP_DIR/mount"/*.app "$TEMP_DIR/app.app"
+            # Copy all DMG contents to preserve structure (Applications link, etc.)
+            mkdir -p "$TEMP_DIR/dmg_contents"
+            cp -r "$TEMP_DIR/mount"/* "$TEMP_DIR/dmg_contents/"
+            
+            # Find the app in the copied contents
+            APP_NAME=$(ls "$TEMP_DIR/dmg_contents" | grep "\.app$" | head -1)
+            if [ -z "$APP_NAME" ]; then
+              echo "❌ No app found in DMG contents"
+              exit 1
+            fi
             
             # Unmount the DMG
             hdiutil detach "$TEMP_DIR/mount"
             
-            # Apply the fix to the copied app
-            codesign --force --deep --sign - "$TEMP_DIR/app.app"
+            # Apply the fix to the app while preserving its name
+            echo "🔧 Applying code signing fix to $APP_NAME..."
+            codesign --force --deep --sign - "$TEMP_DIR/dmg_contents/$APP_NAME"
             
             # Verify the fix
             echo "🔍 Verifying code signing fix..."
-            codesign -dvvv "$TEMP_DIR/app.app" | grep -E "(Sealed Resources|Info.plist)" || echo "⚠️ Verification incomplete"
+            codesign -dvvv "$TEMP_DIR/dmg_contents/$APP_NAME" | grep -E "(Sealed Resources|Info.plist)" || echo "⚠️ Verification incomplete"
             
-            # Create new DMG with the fixed app
+            # Create new DMG with the fixed app and preserved structure
             DMG_NAME=$(basename "$DMG_PATH")
             TEMP_DMG_PATH="${DMG_PATH%.*}_temp"
-            echo "📦 Creating new DMG with fixed app..."
-            hdiutil create -srcfolder "$TEMP_DIR/app.app" -volname "prompalette-staging" -ov -format UDZO "$TEMP_DMG_PATH"
+            echo "📦 Creating new DMG with fixed app and preserved structure..."
+            hdiutil create -srcfolder "$TEMP_DIR/dmg_contents" -volname "prompalette-staging" -ov -format UDZO "$TEMP_DMG_PATH"
             
             # Replace the original DMG
             mv "$TEMP_DMG_PATH.dmg" "$DMG_PATH"


### PR DESCRIPTION
Issues identified from staging test:
- App name was changed to 'app' instead of preserving original name
- Applications folder shortcut was missing from DMG

Changes:
- Copy entire DMG contents to preserve structure (Applications link, etc.)
- Dynamically find app name and preserve it during code signing fix
- Create new DMG from complete structure instead of just the app

This ensures the DMG maintains proper installer experience while fixing code signing.

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## 📝 Description

Brief description of changes made.

## 🔗 Related Issues

Fixes #(issue number)

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates

## ✅ Quality Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## 🔍 Testing

### Test Commands Run
- [ ] `pnpm typecheck` - No type errors
- [ ] `pnpm build` - Builds successfully  
- [ ] `pnpm lint` - No lint errors
- [ ] `pnpm test` - All tests pass

### Manual Testing
Describe the tests you ran to verify your changes:

1. Test A
2. Test B
3. Test C

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 📋 Additional Notes

Any additional information that reviewers should know.