### PR TITLE
fix: Add DMG content verification to prevent system mount issues

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -209,9 +209,32 @@ jobs:
             # Mount the DMG
             hdiutil attach "$DMG_PATH" -mountpoint "$TEMP_DIR/mount" -readonly -noautoopen
             
-            # Copy all DMG contents to preserve structure (Applications link, etc.)
+            # Check and copy only relevant DMG contents
             mkdir -p "$TEMP_DIR/dmg_contents"
-            cp -r "$TEMP_DIR/mount"/* "$TEMP_DIR/dmg_contents/"
+            
+            # List mounted contents for debugging
+            echo "🔍 Mounted DMG contents:"
+            ls -la "$TEMP_DIR/mount/"
+            
+            # Verify this is actually our DMG and not system Applications
+            if [ -f "$TEMP_DIR/mount/Applications" ]; then
+              # Applications is a symlink (normal DMG)
+              echo "✅ Found Applications symlink"
+              cp -r "$TEMP_DIR/mount"/* "$TEMP_DIR/dmg_contents/"
+            elif [ -d "$TEMP_DIR/mount/Applications" ] && [ "$(ls -1 "$TEMP_DIR/mount/" | wc -l)" -gt 10 ]; then
+              # Applications is a directory with many items (system mount - ERROR)
+              echo "❌ ERROR: Mounted system Applications folder instead of DMG"
+              echo "This indicates a problem with DMG creation or mounting"
+              exit 1
+            else
+              # Copy selectively to avoid system files
+              echo "⚠️ Selective copy to avoid system files"
+              for item in "$TEMP_DIR/mount"/*; do
+                if [[ "$(basename "$item")" == *.app ]] || [[ "$(basename "$item")" == "Applications" ]]; then
+                  cp -r "$item" "$TEMP_DIR/dmg_contents/"
+                fi
+              done
+            fi
             
             # Find the app in the copied contents
             APP_NAME=$(ls "$TEMP_DIR/dmg_contents" | grep "\.app$" | head -1)


### PR DESCRIPTION
Root cause: DMG mounting was including system Applications folder causing disk space and permission errors

Changes:
- Add debugging output to show mounted contents
- Verify DMG structure before copying
- Detect if system Applications mounted (error condition)
- Selective copy for safety when needed
- Exit early if system mount detected

This prevents copying entire system Applications folder (Xcode, etc.) which was causing 'No space left on device' errors.

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## 📝 Description

Brief description of changes made.

## 🔗 Related Issues

Fixes #(issue number)

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates

## ✅ Quality Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## 🔍 Testing

### Test Commands Run
- [ ] `pnpm typecheck` - No type errors
- [ ] `pnpm build` - Builds successfully  
- [ ] `pnpm lint` - No lint errors
- [ ] `pnpm test` - All tests pass

### Manual Testing
Describe the tests you ran to verify your changes:

1. Test A
2. Test B
3. Test C

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## 📋 Additional Notes

Any additional information that reviewers should know.